### PR TITLE
Add support for Light selection using Dimmer

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -80,6 +80,13 @@
 				"required": false,
 				"description": "Do not delete accessories when syncing"
 			},
+			"Light_as_Dimmer": {
+				"title": "Use Dimmer for Light",
+				"type": "boolean",
+				"default": false,
+				"required": false,
+				"description": "Light are switches by default, using Dimmer allows for selection similar to WebUI (Using %)"
+			},
 			"excludedDevices": {
 				"title": "Exluded Devices",
 				"type": "array",
@@ -103,6 +110,7 @@
 				"mqtt.username",
 				"mqtt.password",
 				"VSP_as_Fan",
+				"Light_as_Dimmer",
 				"no_delete_on_sync"
 			]
 		}, {

--- a/index.js
+++ b/index.js
@@ -153,6 +153,12 @@ AqualinkdPlatform.prototype = {
             this.log("Device " + device.name + " changing to Dimmer");
             this.isDimmerEnabled=true;
           }
+          if ((typeof this.config.Light_as_Dimmer !== 'undefined') && (this.config.Light_as_Dimmer == true) &&
+              device.type == Constants.adDeviceSwitch && device.hasOwnProperty("type_ext") && device.type_ext == Constants.adDeviceSwitchPrg){
+            device.type = Constants.adDeviceDimmer;
+            this.forceLog("Device " + device.name + " changing to Dimmer");
+            this.isDimmerEnabled=true;
+          }
 
           var existingAccessory = this.accessories.find(function (existingAccessory) {
             return existingAccessory.id == device.id;

--- a/lib/aqualinkd_accessory.js
+++ b/lib/aqualinkd_accessory.js
@@ -17,6 +17,11 @@ function AqualinkdAccessory(platform, platformAccessory, id, device, uuid) {
   this.id = device.id;
   this.name = device.name;
   this.type = device.type;
+  if (device.type == Constants.adDeviceDimmer && device.hasOwnProperty("Light_Program_Total")) {
+    this.Light_Program_Step = 100 / device.Light_Program_Total;
+  } else {
+    this.Light_Progrom_Step = 1;
+  }
 
   this.setStateLastCalled = Date.now();
  
@@ -303,7 +308,7 @@ AqualinkdAccessory.prototype = {
       this.getCharacteristic(service, Characteristic.Brightness).setProps({
         minValue: 0,
         maxValue: 100,
-        minStep: 1
+        minStep: this.Light_Program_Step
       }).on('set', this.setValue.bind(this)).on('get', this.getValue.bind(this));
     } else if (this.type === Constants.adDeviceVSPfan) {
       service = this.getService(Service.Fan);


### PR DESCRIPTION
For AquaLinkD panel that support light selection as Dimmer, switch device type to Dimmer if configuration option 'Light_as_Dimmer' is enabled.

Light setting is divided from 100% based on the number of light mode available. Each region represents a light program mode.

This is tested on PDA-PS6 panel.