### PR TITLE
Fix sensor for Homebridge

### DIFF
--- a/lib/aqualinkd_accessory.js
+++ b/lib/aqualinkd_accessory.js
@@ -528,6 +528,10 @@ AqualinkdAccessory.prototype = {
       //value = Utils.parseFloatTemp(message);
       value = Utils.parseAccessoryValue(this.type, message);
       characteristic = this.getCharacteristic(service, Characteristic.CurrentTemperature);
+    } else if (topic.match("/Sensor/Aux_S[1-9]") && this.id.match("Aux_S[1-9]")) {
+        value = Utils.parseAccessoryValue(this.type, message);
+        service = this.getService(Service.TemperatureSensor);
+        characteristic = this.getCharacteristic(service, Characteristic.CurrentTemperature);
     }
     // Now handle multiple devices using same MQTT message
 


### PR DESCRIPTION
Due to sensor name with "Sensor", sensors for HomeBridge is broken. To fix this, need to explicit check topic name and sensor name with 'Sensor'.